### PR TITLE
Array serialization fix

### DIFF
--- a/kvin.js
+++ b/kvin.js
@@ -317,7 +317,7 @@ function unprepare$Array (seen, po, position) {
       last = po.arr[i]
     } else {
       a.push(po.arr[i])
-      last = prepare$primitive(a[i], 'unprepare$Array')
+      last = prepare$primitive(a[a.length-1], 'unprepare$Array')
     }
   }
 

--- a/tests/yarn.simple
+++ b/tests/yarn.simple
@@ -27,7 +27,7 @@ let c = kvin.unmarshal(b);
 
 let allSame = true;
 for (let i = 0; i < c.length; i++) {
-  for (let j = 0; j < c.length; j++) {
+  for (let j = 0; j < c[i].length; j++) {
     if (a[i][j] !== c[i][j]) {
       allSame = false;
       console.error(`diff at line ${i+1}, character ${j+1}; ${a[i][j]} !== ${c[i][j]}`);


### PR DESCRIPTION
When unmarshalling arrays, the value 'last' was set to the value at a[i], where a is the unmarshalled list and i is the iteration counter for the for loop that is unmarshalling the list. However, in your list compression, it was possible for the unmarshalled list to be longer than this iteration count, so the last value wasn't being set properly. Fixed that by now setting it to a[a.length -1]