### PR TITLE
Properly find length of naive typed array marshal

### DIFF
--- a/kvin.js
+++ b/kvin.js
@@ -933,6 +933,8 @@ KVIN.prototype.prepare$ArrayBuffer = function prepare$ArrayBuffer (o) {
     }
   }
 
+  naiveJSONLen = naive ? JSON.stringify(naive).length : Infinity
+
   ab8 = this.prepare$ArrayBuffer8(o)
   if (this.tune !== "size") {
     if (naive && naive.length < ab8.length) {
@@ -942,7 +944,6 @@ KVIN.prototype.prepare$ArrayBuffer = function prepare$ArrayBuffer (o) {
   }
 
   ab16 = this.prepare$ArrayBuffer16(o)
-  naiveJSONLen = naive ? naive.length + 2 : Infinity
   ab8JSONLen = JSON.stringify(ab8).length;
   ab16JSONLen = ab16 ? JSON.stringify(ab16).length : Infinity
 


### PR DESCRIPTION
Originally length was found through `naive.length + 2`. This is undefined since naive is an object, so the result was naiveJSONLen being set to `NaN`. This actually made it so that the ab8 list was always the chosen way to marshal data, even if it wasn't optimal. This fixes that by JSON.stringifying the naive object to get it's proper length.