### PR TITLE
Bugfix - kvin fails to marshal object w/ BigInt type property

### DIFF
--- a/kvin.js
+++ b/kvin.js
@@ -716,6 +716,9 @@ KVIN.prototype.prepare =  function prepare (seen, o, where) {
       case 'number':
         po[prop] = prepare$number(o[prop]);
         break;
+      case 'bigint':
+        po[prop] = prepare$bigint(o[prop]);
+        break;
       case 'boolean':
       case 'string':
         po[prop] = prepare$primitive(o[prop], where + '.' + prop)

--- a/tests/bigint.simple
+++ b/tests/bigint.simple
@@ -12,3 +12,10 @@ KVIN = require('../kvin');
 
 if (KVIN.parse(KVIN.stringify(bi)) !== bi)
   throw new Error('bigint bug');
+
+let obj = {bigint: bi};
+if (KVIN.parse(KVIN.stringify(obj)).bigint !== obj.bigint)
+  throw new Error('bigint bug');
+
+
+


### PR DESCRIPTION
There is a case where marshalling an object that contains a BigInt type fails, specifically at the preparation level.
This commit adds the fix.
partially resolves : DCP-3098
*rest of resolution in other repos*